### PR TITLE
Get the original image size accurately.

### DIFF
--- a/src/jquery.photoswipe.js
+++ b/src/jquery.photoswipe.js
@@ -47,9 +47,10 @@ function PhotoSwipeMounter($) {
         if (wh_value) {
             d.resolve(wh_value);
         } else {
+            var originalSrc = $img.data('original-src') || $img.attr('src');
             $(`<img>`).on('load', function () {
                 d.resolve(this[wh]);
-            }).attr('src', $img.attr('src'));
+            }).attr('src', originalSrc);
         }
 
         return d.promise();


### PR DESCRIPTION
When the original image is specified with `data-original-src`, get from the size of the original image.